### PR TITLE
Catch nil return of Process.whereis/1 in process_check/1 macro

### DIFF
--- a/lib/ex_health.ex
+++ b/lib/ex_health.ex
@@ -110,7 +110,7 @@ defmodule ExHealth do
 
     quote do
       def unquote(function_name)() do
-        with pid <- Process.whereis(unquote(module)),
+        with pid when not is_nil(pid) <- Process.whereis(unquote(module)),
              info <- Process.info(pid),
              {:ok, status} <- Keyword.fetch(info, :status),
              status == :running || :waiting do


### PR DESCRIPTION
In `ExHealth.process_check/1` macro there are cases where the name of the process (module) being passed is either unregistered or stopped thus making `Process.whereis/1` return a `null` value. Eventually it will be passed to `Process.info/1` which will raise an error.

```elixir
defmacro process_check({_, _, module_list} = _module) do
    {module, _} = Code.eval_string(Enum.join(module_list, "."))
    function_name = String.to_atom("#{@function_prefix}" <> Enum.join(module_list, "_"))

    quote do
      def unquote(function_name)() do
        with pid <- Process.whereis(unquote(module)),
             info <- Process.info(pid),
             {:ok, status} <- Keyword.fetch(info, :status),
             status == :running || :waiting do
          :ok
        else
          nil -> {:error, "no proc"}
          _ -> {:error, "process not running/waiting"}
        end
      end
    end
  end
```

Thus, this PR resolves the following:
Direct Process.whereis/1 nil result (caused by an unregistered or stopped process) to the else clause so it will return an error tuple instead. Tests are also written for those cases.