### PR TITLE
Readme and example updated to current implemention

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Then you must define a module `MyApplication.HealthChecks` with some checks:
 
 ```elixir
 defmodule MyApplication.HealthChecks do
+  import ExHealth
   process_check(MyApplication.CacheServer)
 
-  test "Redis" do
+  health_check "Redis" do
     MyRedis.ping() # This should return :ok | {:error, "Message"}
   end
 end

--- a/examples/phoenix_example/lib/phoenix_example_web/health_checks.ex
+++ b/examples/phoenix_example/lib/phoenix_example_web/health_checks.ex
@@ -2,8 +2,10 @@ defmodule PhoenixExampleWeb.HealthChecks do
   import ExHealth
 
   health_check("Database") do
-    %{num_rows: 1, rows: [res | _]} = Ecto.Adapters.SQL.query!(PhoenixExample.Repo, "SELECT 1")
-    [1] == res
+    case Ecto.Adapters.SQL.query(PhoenixExample.Repo, "SELECT 1") do
+      {:ok, %{num_rows: 1, rows: [[1]]}} -> :ok
+      _ -> {:error, "Database unavailable"}
+    end
   end
 
   process_check(PhoenixExampleWeb.Endpoint)


### PR DESCRIPTION
The example block in the README did not correspond to the actual implementation

In the phoenix example the provided example Postgres check did not actually conform to the expected return values but merely worked because all exceptions are handled. While it does work it is not a good example for someone trying to implement their own health check based on looking at the example code